### PR TITLE
Fix AutoScript Extract/Deploy Confuses Attribute LaunchPoint Events

### DIFF
--- a/resources/sharptree.autoscript.deploy.js
+++ b/resources/sharptree.autoscript.deploy.js
@@ -591,7 +591,7 @@ function deployScript(scriptSource, language) {
                             ) {
                                 scriptLaunchPoint.setValue(
                                     'ATTRIBUTEEVENT',
-                                    '0'
+                                    '1' // Fix https://github.com/sharptree/vscode-autoscript-deploy/issues/28
                                 );
                             } else if (
                                 typeof element.initializeValue !==
@@ -600,7 +600,7 @@ function deployScript(scriptSource, language) {
                             ) {
                                 scriptLaunchPoint.setValue(
                                     'ATTRIBUTEEVENT',
-                                    '1'
+                                    '0' // Fix https://github.com/sharptree/vscode-autoscript-deploy/issues/28
                                 );
                             } else if (
                                 typeof element.validate !== 'undefined' &&

--- a/resources/sharptree.autoscript.extract.js
+++ b/resources/sharptree.autoscript.extract.js
@@ -468,10 +468,12 @@ function extractScriptConfiguration(autoScript) {
                     scriptLaunchPoint.getString('ATTRIBUTENAME');
 
                 switch (scriptLaunchPoint.getInt('ATTRIBUTEEVENT')) {
-                    case 0:
+                    // Fix https://github.com/sharptree/vscode-autoscript-deploy/issues/28
+                    case 1:
                         launchPoint.initializeAccessRestriction = true;
                         break;
-                    case 1:
+                    // Fix https://github.com/sharptree/vscode-autoscript-deploy/issues/28
+                    case 0:
                         launchPoint.initializeValue = true;
                         break;
                     case 2:


### PR DESCRIPTION
Hello,
As talked in https://github.com/sharptree/vscode-autoscript-deploy/issues/28
in the Automation Script SHARPTREE.AUTOSCRIPT.DEPLOY version v1.48.0, the ATTRIBUTEEVENT field values are encdoed as:

```
0 === initializeAccessRestriction // confuseed with initializeValue
1 === initializeValue // confused with initializeAccessRestriction
2 === validate
3 === retrieveList
4 === runAction
```

However, it appears to me that Maximo base code is expecting the encoding to be:

```
0 === initializeValue
1 === initializeAccessRestriction
2 === validate
3 === retrieveList
4 === runAction
```